### PR TITLE
ENH: Simplify AEF and fix timing of localiser

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,9 +16,9 @@ data_root = (Path(__file__).parent / ".." / "Natural_Conversations_study").resol
 bids_root = data_root / f'{study_name}-bids'
 interactive = False
 sessions = "all"
-task = "localizer"
+task = "conversation"
 subjects = ["01"]  # "all" TODO: Process all
-runs = ["01"]
+runs = ["01", "02", "03", "04", "05", "06"]
 
 use_maxwell_filter = False
 # find_flat_channels_meg = True  # TODO: Enable for files w/o cal + cross-talk
@@ -33,11 +33,13 @@ epochs_decim = 5
 process_rest = True
 
 reject = "autoreject_global"
-conditions = ["ba", "da"]
+conditions = ["ba", "da", "dummy"]  # dummy just to make event processing happy
 epochs_tmin = -0.2
 epochs_tmax = 0.5
 baseline = (None, 0)
 spatial_filter = 'ssp'
+n_proj_ecg = dict(n_mag=1, n_eeg=0)
+n_proj_eog = dict(n_mag=1, n_eeg=1)
 
 run_source_estimation = False
 spacing = "oct6"

--- a/simple_AEF_AEP.py
+++ b/simple_AEF_AEP.py
@@ -2,223 +2,35 @@
 #
 # Simple AEF & AEP analysis (for sanity check)
 #
-# Authors: Paul Sowman, Judy Zhu
+# Authors: Paul Sowman, Judy Zhu, Eric Larson
 
 #######################################################################################
 
-import os
+from pathlib import Path
+
 import mne
-import meegkit
-import glob
-import numpy as np
-import copy
+import mne_bids
+import meegkit  # noqa
 
-import my_preprocessing
-import utils
+bids_root = Path("../Natural_Conversations_study/natural-conversations-bids").resolve(strict=True)
+bids_path = mne_bids.BIDSPath(subject="01", datatype="meg", task="conversation", run="06", root=bids_root)
+raw = mne_bids.read_raw_bids(bids_path).load_data()
+picks_ref = ["MISC 001", "MISC 002", "MISC 003"]
 
+# Apply reference regression
+raw, _ = mne.preprocessing.regress_artifact(raw, picks="meg", picks_artifact=picks_ref)
 
-# set up file and folder paths here
-exp_dir = "/mnt/d/Work/analysis_ME206/"; #"/home/jzhu/analysis_mne/"
-subject_MEG = 'G20'; #'gopro_test'; #'MMN_test' #'220112_p003' #'FTD0185_MEG1441'
-task = 'localiser'; #'_1_oddball' #''
-run_name = '_TSPCA'
+# Apply TSPCA
+# noisy_data = raw.get_data(picks="meg").T
+# noisy_ref = raw.get_data(picks=picks_ref).T
+# data_after_tspca, idx = meegkit.tspca.tsr(noisy_data, noisy_ref)[0:2]
+# raw._data[0:160] = data_after_tspca.T
+# raw.plot()
 
-# the paths below should be automatic
-data_dir = exp_dir + "data/"
-processing_dir = exp_dir + "processing/"
-results_dir = exp_dir + "results/"
-meg_dir = data_dir + subject_MEG + "/meg/"
-eeg_dir = data_dir + subject_MEG + "/eeg/"
-save_dir_meg = processing_dir + "meg/" + subject_MEG + "/" # where to save the epoch files for each subject
-save_dir_eeg = processing_dir + "eeg/" + subject_MEG + "/"
-figures_dir_meg = results_dir + 'meg/sensor/' + task + run_name + '/Figures/' # where to save the figures for all subjects
-figures_dir_eeg = results_dir + 'eeg/sensor/' + task + '/Figures/'
-epochs_fname_meg = save_dir_meg + subject_MEG + "_" + task + run_name + "-epo.fif"
-epochs_fname_eeg = save_dir_eeg + subject_MEG + "_" + task + "-epo.fif"
-# create the folders if needed
-os.system('mkdir -p ' + save_dir_meg)
-os.system('mkdir -p ' + save_dir_eeg)
-os.system('mkdir -p ' + figures_dir_meg)
-os.system('mkdir -p ' + figures_dir_eeg)
-
-
-#%% === Read raw MEG data === #
-
-#print(glob.glob("*_oddball.con"))
-fname_raw = glob.glob(meg_dir + "*" + task + ".con")
-fname_elp = glob.glob(meg_dir + "*.elp")
-fname_hsp = glob.glob(meg_dir + "*.hsp")
-fname_mrk = glob.glob(meg_dir + "*.mrk")
-
-# Raw extraction ch misc 23-29 = triggers
-# ch misc 007 = audio
-raw = mne.io.read_raw_kit(
-    fname_raw[0],  # change depending on file i want
-    mrk=fname_mrk[0],
-    elp=fname_elp[0],
-    hsp=fname_hsp[0],
-    stim=[*[166], *range(176, 190)],
-    slope="+",
-    stim_code="channel",
-    stimthresh=2,  # 2 for adult (1 for child??)
-    preload=True,
-    allow_unknown_format=False,
-    verbose=True,
-)
-
-# Apply TSPCA for noise reduction
-noisy_data = raw.get_data(picks="meg").transpose()
-noisy_ref = raw.get_data(picks=[160,161,162]).transpose()
-data_after_tspca, idx = meegkit.tspca.tsr(noisy_data, noisy_ref)[0:2]
-raw._data[0:160] = data_after_tspca.transpose()
-
-# browse data to identify bad sections & bad channels
-raw.plot()
-
-
-# Filtering & ICA
-raw = my_preprocessing.reject_artefact(raw, 1, 40, False, '')
-
-
-# Trigger detection & timing correction
-events_corrected, AD_delta = utils.triggerCorrection(raw, subject_MEG)
-
-# specify the event IDs
-event_ids = {
-    "ba": 181,
-    "da": 182,
-}
-
-
-#%% === Epoching === #
-if not os.path.exists(epochs_fname_meg):
-    epochs = mne.Epochs(raw, events_corrected, event_id=event_ids, tmin=-0.1, tmax=0.41, preload=True)
-
-    conds_we_care_about = ["ba", "da"]
-    epochs.equalize_event_counts(conds_we_care_about)
-
-    # downsample to 100Hz
-    print("Original sampling rate:", epochs.info["sfreq"], "Hz")
-    epochs_resampled = epochs.copy().resample(100, npad="auto")
-    print("New sampling rate:", epochs_resampled.info["sfreq"], "Hz")
-
-    # save for later use (e.g. in Source_analysis script)
-    epochs_resampled.save(epochs_fname_meg, overwrite=True)
-
-# plot ERFs
-if not os.path.exists(figures_dir_meg + subject_MEG + '_AEF_butterfly.png'):
-    epochs_resampled = mne.read_epochs(epochs_fname_meg)
-
-    fig = epochs_resampled.average().plot(spatial_colors=True, gfp=True)
-    fig.savefig(figures_dir_meg + subject_MEG + '_AEF_butterfly.png')
-
-    fig2 = mne.viz.plot_compare_evokeds(
-        [
-            epochs_resampled["ba"].average(),
-            epochs_resampled["da"].average(),
-        ],
-        #combine = 'mean' # combine channels by taking the mean (default is GFP)
-    )
-    fig2[0].savefig(figures_dir_meg + subject_MEG + '_AEF_gfp.png')
-
-
-
-#%% === Analyse EEG data === #
-
-# Read raw EEG data
-fname_eeg = glob.glob(eeg_dir + "*" + task + ".eeg")
-fname_vhdr = glob.glob(eeg_dir + "*" + task + ".vhdr")
-raw_eeg = mne.io.read_raw_brainvision(fname_vhdr[0], preload=True)
-
-# set channel types explicitly as these are not read in automatically
-raw_eeg.set_channel_types({'32': 'ecg', '63': 'eog'})
-
-# Filtering & ICA
-raw_eeg = my_preprocessing.reject_artefact(raw_eeg, 1, 40, False, '')
-
-# Browse the raw data
-raw_eeg.plot()
-
-
-# Offline rereferencing
-# https://mne.tools/stable/auto_tutorials/preprocessing/55_setting_eeg_reference.html
-
-# add the online reference channel 'FCz' back (all zeros)
-raw_eeg_reref = mne.add_reference_channels(raw_eeg, ref_channels=['64'])
-# use average reference
-raw_eeg_reref.set_eeg_reference(ref_channels="average") # data are modified in-place
-
-# Note: bad channels are not included when computing the average.
-# TODO: to avoid an unbalanced average ref (e.g. when more channels are removed
-# in one hemisphere), we should probably interpolate the bad channels first! 
-
-
-# Find events embedded in data
-eeg_events, _ = mne.events_from_annotations(raw_eeg_reref)
-#print(eeg_events[:5])
-
-# remove first 2 triggers (new segment start & one extra trigger sent by PTB script)
-eeg_events = np.delete(eeg_events, [0,1], 0) 
-if subject_MEG == 'G03':
-    eeg_events = np.delete(eeg_events, 198, 0) # MEG data is missing the final trigger, so remove it from EEG data too
-
-# specify the event IDs
-eeg_event_ids = {
-    "ba": 53,
-    "da": 54,
-}
-
-assert len(eeg_events) == len(AD_delta) # sanity check
-
-# Adjust trigger timing based on delay values from MEG data
-eeg_events_corrected = copy.copy(eeg_events) # work on a copy so we don't affect the original
-for i in range(len(eeg_events)):
-    eeg_events_corrected[i,0] += AD_delta[i] # update event timing
-
-
-# Epoching
-if not os.path.exists(epochs_fname_eeg):
-    epochs_eeg = mne.Epochs(raw_eeg_reref, eeg_events_corrected, event_id=eeg_event_ids, tmin=-0.1, tmax=0.41, preload=True)
-
-    conds_we_care_about = ["ba", "da"]
-    epochs_eeg.equalize_event_counts(conds_we_care_about)
-
-    # downsample to 100Hz
-    epochs_eeg_resampled = epochs_eeg.copy().resample(100, npad="auto")
-
-    # save for later use
-    epochs_eeg_resampled.save(epochs_fname_eeg, overwrite=True)
-
-# plot ERPs
-if not os.path.exists(figures_dir_eeg + subject_MEG + '_AEP_butterfly.png'):
-    epochs_eeg_resampled = mne.read_epochs(epochs_fname_eeg)
-
-    fig = epochs_eeg_resampled.average().plot(spatial_colors=True, gfp=True)
-    fig.savefig(figures_dir_eeg + subject_MEG + '_AEP_butterfly.png')
-    # Note: it seems like channel locations are not available from vhdr file;
-    # you need to specify these explicitly using epochs.set_montage()
-
-    fig2 = mne.viz.plot_compare_evokeds(
-        [
-            epochs_eeg_resampled["ba"].average(),
-            epochs_eeg_resampled["da"].average(),
-        ],
-        #combine = 'mean' # combine channels by taking the mean (default is GFP)
-    )
-    fig2[0].savefig(figures_dir_eeg + subject_MEG + '_AEP_gfp.png')
-
-
-
-#%% === Make alternative plots === #
-'''
-normal = mne.read_epochs(save_dir_meg + subject_MEG + "_localiser_normal-epo.fif")
-gopro = mne.read_epochs(save_dir_meg + subject_MEG + "_localiser_gopro-epo.fif")
-
-# plot 'da' only (normal vs with_gopro)
-mne.viz.plot_compare_evokeds(
-    [
-        normal["da"].average(),
-        gopro["da"].average(),
-    ]
-)
-'''
+raw.filter(0.5, 40)
+events, event_id = mne.events_from_annotations(raw)
+assert event_id == {"ba": 1, "da": 2}
+# downsample to 200 Hz
+epochs = mne.Epochs(raw, events, event_id=event_id, tmin=-0.1, tmax=0.41, preload=True, decim=5, baseline=None)
+epochs.equalize_event_counts(event_id)
+fig = epochs.average().plot(spatial_colors=True, gfp=True)

--- a/utils.py
+++ b/utils.py
@@ -4,7 +4,7 @@ import numpy as np
 import copy
 
 
-def triggerCorrection(raw, subject_MEG):
+def triggerCorrection(raw, subject_MEG, *, plot=True):
     """Adjust trigger timing based on MEG audio channel.
 
     Parameters
@@ -12,13 +12,15 @@ def triggerCorrection(raw, subject_MEG):
     raw : instance of Raw
     subject_MEG : string
         Used for specifying special thresholds for certain subjects
-        
+    plot : bool
+        If True (default), open diagnostic plot.
+
     Returns
     -------
     events_corrected : array, shape (m, 3)
         The events with corrected timing.
     AD_delta : list of integers
-        The audio delay values (i.e. offset between normal triggers and 
+        The audio delay values (i.e. offset between normal triggers and
         detected sound onset in audio channel signal), in ms.
     """
 
@@ -78,28 +80,29 @@ def triggerCorrection(raw, subject_MEG):
             missing.append(i)
     # discard events which could not be corrected
     events_corrected = np.delete(events_corrected, missing, 0)
-    print("Could not correct", len(missing), "events - these were discarded!")
+    if missing:
+        print("Could not correct", len(missing), "events - these were discarded!")
 
     # histogram showing the distribution of audio delays
-    n, bins, patches = plt.hist(
-        x=AD_delta, bins="auto", color="#0504aa", alpha=0.7, rwidth=0.85
-    )
-    plt.grid(axis="y", alpha=0.75)
-    plt.xlabel("Delay (ms)")
-    plt.ylabel("Frequency")
-    plt.title("Audio Detector Delays")
-    plt.text(
-        70,
-        50,
-        r"$mean="
-        + str(round(np.mean(AD_delta)))
-        + ", std="
-        + str(round(np.std(AD_delta)))
-        + "$",
-    )
-    maxfreq = n.max()
-    # set a clean upper y-axis limit
-    plt.ylim(ymax=np.ceil(maxfreq / 10) * 10 if maxfreq % 10 else maxfreq + 10)
+    if plot:
+        _, ax = plt.subplots(layout="constrained")
+        n, bins, patches = ax.hist(
+            x=AD_delta, bins="auto", color="#0504aa", alpha=0.7, rwidth=0.85
+        )
+        ax.grid(axis="y", alpha=0.75)
+        ax.set(xlabel="Delay (ms)", ylabel="Frequency", title="Audio Detector Delays")
+        ax.text(
+            70,
+            50,
+            r"$mean="
+            + str(round(np.mean(AD_delta)))
+            + ", std="
+            + str(round(np.std(AD_delta)))
+            + "$",
+        )
+        maxfreq = n.max()
+        # set a clean upper y-axis limit
+        ax.ylim(ymax=np.ceil(maxfreq / 10) * 10 if maxfreq % 10 else maxfreq + 10)
 
     return events_corrected, AD_delta
 


### PR DESCRIPTION
1. Use `utils.triggerCorrection` on MEG data to correct auditory timing
2. Simplify AEF demo code using BIDS-ified data
3. Use "conversation" as the BIDS task for localizer (with block=06) so MNE-BIDS-Pipeline will process it (hack but works)
4. Add dummy events to conversations so MNE-BIDS-Pipeline will process them (another hack but it works)

Resulting `simple_AEF_AEP.py` figure:

![Screenshot from 2024-01-17 10-47-29](https://github.com/Macquarie-MEG-Research/natural_conversations/assets/2365790/b86cb544-dc6d-4fb0-8aab-a0c6c3534853)

And resulting MBP HTML report (have to zip it to upload it to GH):

[sub-01_task-conversation_report.zip](https://github.com/Macquarie-MEG-Research/natural_conversations/files/13965491/sub-01_task-conversation_report.zip)

You can see the auditory response looks bad because almost all epochs were dropped because of CP1. So next steps I think:

1. Add some bad channel marking to `bidsify.py`, probably based on `autoreject` or flat/large channel detection or (in a worst case) manual inspection of datasets. CP1 is almost certainly bad for subject 1 for example based on the drop log.
2. Add the conversation turns, probably via 1-second annotations (easily reconstructed into contiguous segments if desired) or similar so we can run a simple CSP classifier on them.
3. Take care of [MNE-BIDS-Pipeline issues](https://github.com/mne-tools/mne-bids-pipeline/issues) about 1) using TSPCA and/or reference regression, and 2) saving fully preprocessed raw data in addition to epochs data.

@JD-Zhu feel free to look at the diff and see if you think things here make sense. We can discuss later today!